### PR TITLE
WIP: Use connection config file as with MDS.

### DIFF
--- a/filestore/conf.py
+++ b/filestore/conf.py
@@ -1,6 +1,21 @@
+import os
+import uuid
+import yaml
+import logging
 
-connection_config = {
-    'database': 'filestore',
-    'host': "localhost",
-    'port': 27017,
-}
+logger = logging.getLogger(__name__)
+filename = os.path.join(os.path.expanduser('~'), '.config', 'filestore',
+                        'connection.yml')
+if os.path.isfile(filename):
+    with open(filename) as f:
+        connection_config = yaml.load(f)
+    logger.debug("Using db connection specified in config file. \n%r",
+                 mds_config)
+else:
+    connection_config = {
+        'database': 'test-{0}'.format(uuid.uuid4()),
+        'host': "localhost",
+        'port': 27017,
+        }
+    logger.debug("Using default db connection. \n%r",
+                 connection_config)


### PR DESCRIPTION
Do not merge. This should redone in light of NSLS-II/metadatastore#97. I'm leaving it here as a reminder.

One notable difference: the default db name here includes a random string so that fresh builds of the docs or runs of the tests do not collide. This should probably be handled in the docs/tests themselves when there is a robust facility for switching dbs.