### PR TITLE
ENH: Add handler for AreaDetector data.

### DIFF
--- a/filestore/api.py
+++ b/filestore/api.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import, division, print_function
 
-from .commands import insert_resource, insert_datum, retrieve
+from .commands import insert_resource, insert_datum, retrieve, db_disconnect
 from .retrieve import register_handler, deregister_handler

--- a/filestore/commands.py
+++ b/filestore/commands.py
@@ -21,6 +21,9 @@ def db_connect(func):
 
 def db_disconnect():
     mongoengine.connection.disconnect(ALIAS)
+    Datum._collection = None
+    Resource._collection = None
+    ResourceAttributes._collection = None
 
 
 @db_connect

--- a/filestore/file_readers.py
+++ b/filestore/file_readers.py
@@ -11,7 +11,33 @@ import os.path
 logger = logging.getLogger(__name__)
 
 
-class _HdfMapsHandlerBase(HandlerBase):
+class _HDF5HandlerBase(HandlerBase):
+
+    def open(self):
+        if self._file:
+            return
+        self._file = h5py.File(self._filename)
+
+    def close(self):
+        super(HDF5HandlerBase, self).close()
+        self._file.close()
+
+
+class HDF5DatasetSliceHandler(_HDF5HandlerBase):
+    "Handler for Stuart's first detector demo"
+    def __init__(self, filename, frame_per_point):
+        self._filename = filename
+        self.open()
+
+    def __call__(self, point_number):
+        dataset_name = '/entry/data/data'
+        # Don't read out the dataset until it is requested for the first time.
+        if not hasattr(self, '_dataset'):
+            self._dataset = self._file[dataset_name]
+        return self._dataset[point_number, :, :]
+
+
+class _HdfMapsHandlerBase(_HDF5HandlerBase):
     """
     Reader for XRF data stored in hdf5 files.
 

--- a/filestore/retrieve.py
+++ b/filestore/retrieve.py
@@ -14,6 +14,8 @@ class HandlerBase(object):
     make them usable in context managers by provding stubs of
     ``__enter__``, ``__exit__`` and ``close``
     """
+    specs = set()
+
     def __enter__(self):
         return self
 

--- a/filestore/test/test_commands.py
+++ b/filestore/test/test_commands.py
@@ -8,8 +8,9 @@ import mongoengine
 import mongoengine.connection
 
 
-import filestore.commands as fc
-import filestore.retrieve as fsr
+import filestore.retrieve
+from filestore.api import (insert_resource, insert_datum, retrieve,
+                           register_handler, db_disconnect)
 from filestore.odm_templates import Datum, ALIAS
 from numpy.testing import assert_array_equal
 from nose.tools import assert_raises
@@ -23,31 +24,30 @@ conn = None
 def setup():
     global conn
     # make sure nothing is connected
-    fc.db_disconnect()
+    db_disconnect()
     # make sure it _is_ connected
     conn = mongoengine.connect(db_name, host='localhost',
                         alias=ALIAS)
 
     # register the dummy handler to use
-    fsr.register_handler('syn-mod', SynHandlerMod)
+    register_handler('syn-mod', SynHandlerMod)
 
 
 def teardown():
-    fc.db_disconnect()
+    db_disconnect()
     # if we know about a connection, drop the database
     if conn:
         conn.drop_database(db_name)
 
-    del fsr._h_registry['syn-mod']
+    del filestore.retrieve._h_registry['syn-mod']
 
 
 def _insert_syn_data(f_type, shape, count):
-    fb = fc.insert_resource(f_type, '',
-                           {'shape': shape})
+    fb = insert_resource(f_type, '', {'shape': shape})
     ret = []
     for k in range(count):
         r_id = str(uuid.uuid4())
-        fc.insert_datum(fb, r_id, {'n': k + 1})
+        insert_datum(fb, r_id, {'n': k + 1})
         ret.append(r_id)
     return ret
 
@@ -57,10 +57,10 @@ def test_round_trip():
     mod_ids = _insert_syn_data('syn-mod', shape, 10)
 
     for j, r_id in enumerate(mod_ids):
-        data = fc.retrieve(r_id)
+        data = retrieve(r_id)
         known_data = np.mod(np.arange(np.prod(shape)), j + 1).reshape(shape)
         assert_array_equal(data, known_data)
 
 
 def test_non_exist():
-    assert_raises(Datum.DoesNotExist, fc.retrieve, 'aardvark')
+    assert_raises(Datum.DoesNotExist, retrieve, 'aardvark')

--- a/filestore/test/test_handlers.py
+++ b/filestore/test/test_handlers.py
@@ -1,0 +1,64 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+import numpy as np
+import h5py
+import tempfile
+import uuid
+import mongoengine
+import mongoengine.connection
+from filestore.api import (insert_resource, insert_datum, retrieve,
+                           register_handler, deregister_handler, db_disconnect)
+from filestore.odm_templates import ALIAS
+from filestore.file_readers import AreaDetectorHDF5Handler
+from numpy.testing import assert_array_equal
+
+
+db_name = str(uuid.uuid4())
+conn = None
+
+
+def setup():
+    global conn
+    # make sure nothing is connected
+    db_disconnect()
+    # make sure it _is_ connected
+    conn = mongoengine.connect(db_name, host='localhost', alias=ALIAS)
+    print(id(conn.database))
+
+    register_handler('AD_HDF5', AreaDetectorHDF5Handler)
+
+
+def teardown():
+    deregister_handler('AD_HDF5')
+    db_disconnect()
+    # if we know about a connection, drop the database
+    if conn:
+        conn.drop_database(db_name)
+
+
+def test_AD_round_trip():
+    filename = tempfile.NamedTemporaryFile().name
+    f = h5py.File(filename)
+    N = 5
+
+    # Write the data.
+    data = np.multiply.outer(np.arange(N), np.ones((2, 2)))
+    f.create_dataset('/entry/data/data', data=data)
+    f.close()
+
+    # Insert the data records.
+    print(id(conn.database))
+    resource_id = insert_resource('AD_HDF5', filename)
+    datum_ids = [str(uuid.uuid4()) for i in range(N)]
+    for i, datum_id in enumerate(datum_ids):
+        insert_datum(resource_id, datum_id, dict(point_number=i))
+    print(id(conn.database))
+
+    # Retrieve the data.
+    for i, datum_id in enumerate(datum_ids):
+        print(id(conn.database))
+        data = retrieve(datum_id)
+        known_data = i * np.ones((2, 2))
+        assert_array_equal(data, known_data)


### PR DESCRIPTION
This adds a handler to read area detector data in the format spec implemented by @stuwilkins and dubbed 'AD_HDF5'.

The reader is called `HDF5DatasetSliceHandler`, meaning to suggest that it slices into a single Dataset in an HDF5 file. The dataset name, `'/entry/data/data/'`, is hard-coded.

@stuwilkins Instead of hard-coding the dataset name, could your insertion code pass it to `__init__`? Also, it seems that `frame_per_point` is not used. Should that be removed from the `__init__`.