### PR TITLE
API: Add fs_setup and fs_teardown testing utilities.

### DIFF
--- a/filestore/commands.py
+++ b/filestore/commands.py
@@ -25,8 +25,10 @@ def db_disconnect():
     Resource._collection = None
     ResourceAttributes._collection = None
 
+
 def db_connect(database, host, port):
-    connect(db=database, host=host, port=port, alias=ALIAS)
+    return connect(db=database, host=host, port=port, alias=ALIAS)
+
 
 @_ensure_connection
 def insert_resource(spec, resource_path, resource_kwargs=None):

--- a/filestore/test/test_commands.py
+++ b/filestore/test/test_commands.py
@@ -10,31 +10,23 @@ import mongoengine.connection
 
 import filestore.retrieve
 from filestore.api import (insert_resource, insert_datum, retrieve,
-                           register_handler, db_disconnect, db_connect)
+                           register_handler)
 from filestore.odm_templates import Datum
+from filestore.utils.testing import fs_setup, fs_teardown
 from numpy.testing import assert_array_equal
 from nose.tools import assert_raises
 
 from .t_utils import SynHandlerMod
 
-db_name = str(uuid.uuid4())
-conn = None
-
 
 def setup():
-    global conn
-    db_disconnect()
-    db_connect(db_name, 'localhost', 27017)
-
+    fs_setup()
     # register the dummy handler to use
     register_handler('syn-mod', SynHandlerMod)
 
 
 def teardown():
-    db_disconnect()
-    # if we know about a connection, drop the database
-    if conn:
-        conn.drop_database(db_name)
+    fs_teardown()
 
     del filestore.retrieve._h_registry['syn-mod']
 

--- a/filestore/utils/testing.py
+++ b/filestore/utils/testing.py
@@ -1,0 +1,18 @@
+import uuid
+from filestore.api import db_connect, db_disconnect
+
+
+conn = None
+db_name = str(uuid.uuid4())
+
+
+def fs_setup():
+    "Create a fresh database with unique (random) name."
+    global conn
+    db_disconnect()
+    conn = db_connect(db_name, 'localhost', 27017)
+
+def fs_teardown():
+    "Drop the fresh database and disconnect."
+    conn.drop_database(db_name)
+    db_disconnect()

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     author_email=None,
     license="BSD (3-clause)",
     url="https://github.com/NSLS-II/filestore",
-    packages=['filestore'],
+    packages=['filestore', 'filestore.utils'],
     long_description=read('README.md'),
     classifiers=[
         "License :: OSI Approved :: EPICS License",


### PR DESCRIPTION
Now tests can easily create clean, temporary databases like so:

    from filestore.utils.testing import fs_setup, fs_teardown

    def setup():
        fs_setup()

    def teardown():
        fs_teardown()

There is a cousin PR in metadata store. Broker can use them both, hence the names `fs_setup` and `mds_setup`.