### PR TITLE
BLD: Add setup.py requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,4 +82,5 @@ setup(
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 2.7",
     ],
+    requires=['h5py', 'numpy', 'mongoengine', 'jsonschema']
 )


### PR DESCRIPTION
The dataportal Travis builds broke because filestore was not declaring its jsonschema dependency (or in fact any dependencies).