### PR TITLE
ENH: Add AreaDetectorTiffHandler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda update conda --yes
   - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy h5py pims jsonschema
+  - conda install -n testenv --yes -c soft-matter tifffile
   - source activate testenv
   - pip install coveralls mongoengine
   - python setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - numpy
     - six
     - pims
+    - tifffile
     - pyyaml
     - setuptools
     - jsonschema

--- a/filestore/handlers.py
+++ b/filestore/handlers.py
@@ -61,6 +61,9 @@ class AreaDetectorTiffHandler(HandlerBase):
 
     def __call__(self, point_number):
         start, stop = point_number * self._fpp, (point_number + 1) * self._fpp
+        if stop > len(self._image_sequence):
+            raise IntegrityError("Seeking Frame {0} out of {1} frames.".format(
+                stop, len(self._image_sequence)))
         return np.asarray(list(self._image_sequence[start:stop])).squeeze()
 
 

--- a/filestore/handlers.py
+++ b/filestore/handlers.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import logging
+from PIL import Image
 import h5py
 import numpy as np
 import os.path
@@ -44,6 +45,26 @@ class AreaDetectorSPEHandler(HandlerBase):
                       "expected {} frames, found {} frames".format(
                              self._fpp, data.shape[0]))
         return data.squeeze()
+
+
+class AreaDetectorTiffHandler(HandlerBase):
+    specs = {'AD_TIFF'} | HandlerBase.specs
+
+    def __init__(self, fpath, template, filename, frame_per_point=1):
+        self._path = fpath
+        self._fpp = frame_per_point
+        self._template = template
+        self._filename = filename
+        self._f_cache = dict()
+
+    def __call__(self, point_number):
+        if point_number not in self._f_cache:
+            fname = self._template % (self._path,
+                                      self._filename,
+                                      point_number)
+            data = np.asarray(Image.open(fname))
+            self._f_cache[point_number] = data
+        return self._f_cache[point_number]
 
 
 class DummyAreaDetectorHandler(HandlerBase):


### PR DESCRIPTION
Added while XPD because the HDF5 files from the HDF5 handler are mysteriously 500X larger than we expect.

This works in the wild, but has no unit tests at this time. Since it's easy enough to write tests using programmatically-generated TIFFs, we should add unit tests before merging.