### PR TITLE
PRF/API: speed up retrieve

### DIFF
--- a/filestore/commands.py
+++ b/filestore/commands.py
@@ -116,5 +116,4 @@ def retrieve(eid):
     data : ndarray
         The requested data as a numpy array
     """
-    edoc = Datum.objects.get(datum_id=eid)
-    return _get_data(edoc)
+    return _get_data(eid)

--- a/filestore/retrieve.py
+++ b/filestore/retrieve.py
@@ -248,10 +248,15 @@ def get_data(eid, handle_registry=None):
         datum = {k: edoc[k] for k in keys}
         # pull all datum which share this resource
         res = edoc['resource']
+        count = 0
         for dd in d_objs(resource=res):
+            count += 1
             d_id = dd['datum_id']
             if d_id not in _DATUM_CACHE:
                 _DATUM_CACHE[d_id] = {k: dd[k] for k in keys}
+        if count > _DATUM_CACHE.max_size:
+            logger.warn("More datum in a resource than your "
+                        "datum cache can hold.")
 
     handler = get_spec_handler(datum['resource'], handle_registry)
     return handler(**datum['datum_kwargs'])

--- a/filestore/test/test_commands.py
+++ b/filestore/test/test_commands.py
@@ -4,9 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import numpy as np
 import uuid
-import mongoengine
-import mongoengine.connection
-
 
 import filestore.retrieve
 from filestore.api import (insert_resource, insert_datum, retrieve,

--- a/filestore/test/test_retrieve.py
+++ b/filestore/test/test_retrieve.py
@@ -39,48 +39,39 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import logging
 
-
-from filestore.odm_templates import Resource, Datum
-
 import filestore.retrieve as fsr
+import filestore.commands as fsc
+from filestore.utils.testing import fs_setup, fs_teardown
 import numpy as np
 from nose.tools import assert_true, assert_raises, assert_false
 
-from .t_utils import SynHandlerMod, SynHandlerEcho
+from filestore.test.t_utils import SynHandlerMod, SynHandlerEcho
 import uuid
 
 logger = logging.getLogger(__name__)
 
 
-mock_base = Resource(spec='syn-mod',
-                     resource_path='',
-                     resource_kwargs={'shape': (5, 7)})
+def setup():
+    fs_setup()
 
-mock_event = {n: Datum(resource=mock_base,
-                               datum_id=n,
-                               datum_kwargs={'n': n})
-                               for n in range(1, 3)}
+
+def teardown():
+    fs_teardown()
 
 
 def test_get_handler_global():
 
+    mock_base = dict(spec='syn-mod',
+                     resource_path='',
+                     resource_kwargs={'shape': (5, 7)})
+
+    res = fsc.insert_resource(**mock_base)
+
     with fsr.handler_context({'syn-mod': SynHandlerMod}):
 
-        datum = mock_base
-        handle = fsr.get_spec_handler(datum)
+        handle = fsr.get_spec_handler(res.id)
 
         assert_true(isinstance(handle, SynHandlerMod))
-
-
-def _help_test_data(event_doc):
-    data = fsr.get_data(event_doc, {'syn-mod': SynHandlerMod})
-
-    assert_true(np.all(data < event_doc.datum_id))
-
-
-def test_get_data():
-    for v in mock_event.values():
-        yield _help_test_data, v
 
 
 def test_context():


### PR DESCRIPTION
This speeds up datum retival by a factor of 30 by greedily caching
the datum documents the first time we see a resource.  By doing this
we greatly reduce the number of sockets that need to be created.

This changes the internal api of Retrive to no longer take mongoengine
documents.  This should not matter as the public API is un-changed.