### PR TITLE
FIX: clear handler cache on handler deregistration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda update conda --yes
-  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy h5py pims jsonschema
+  - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo=2.8 six pyyaml numpy h5py pims jsonschema
   - conda install -n testenv --yes -c soft-matter tifffile
   - source activate testenv
   - pip install coveralls mongoengine boltons

--- a/filestore/test/test_retrieve.py
+++ b/filestore/test/test_retrieve.py
@@ -78,6 +78,21 @@ def test_get_handler_global():
     assert_not_in(cache_key, fsr._HANDLER_CACHE)
 
 
+def test_overwrite_global():
+    mock_base = dict(spec='syn-mod',
+                     resource_path='',
+                     resource_kwargs={'shape': (5, 7)})
+
+    res = fsc.insert_resource(**mock_base)
+
+    cache_key = (str(res.id), SynHandlerMod.__name__)
+    with fsr.handler_context({'syn-mod': SynHandlerMod}):
+        fsr.get_spec_handler(res.id)
+        assert_in(cache_key, fsr._HANDLER_CACHE)
+        fsr.register_handler('syn-mod', SynHandlerEcho, overwrite=True)
+        assert_not_in(cache_key, fsr._HANDLER_CACHE)
+
+
 def test_context():
     with SynHandlerMod('', (4, 2)) as hand:
         for j in range(1, 5):

--- a/filestore/test/test_retrieve.py
+++ b/filestore/test/test_retrieve.py
@@ -43,7 +43,8 @@ import filestore.retrieve as fsr
 import filestore.commands as fsc
 from filestore.utils.testing import fs_setup, fs_teardown
 import numpy as np
-from nose.tools import assert_true, assert_raises, assert_false
+from nose.tools import (assert_true, assert_raises, assert_false,
+                        assert_in, assert_not_in)
 
 from filestore.test.t_utils import SynHandlerMod, SynHandlerEcho
 import uuid
@@ -66,12 +67,15 @@ def test_get_handler_global():
                      resource_kwargs={'shape': (5, 7)})
 
     res = fsc.insert_resource(**mock_base)
-
+    cache_key = (str(res.id), SynHandlerMod.__name__)
     with fsr.handler_context({'syn-mod': SynHandlerMod}):
 
         handle = fsr.get_spec_handler(res.id)
 
         assert_true(isinstance(handle, SynHandlerMod))
+        assert_in(cache_key, fsr._HANDLER_CACHE)
+
+    assert_not_in(cache_key, fsr._HANDLER_CACHE)
 
 
 def test_context():


### PR DESCRIPTION
Fixes issues with development workflow of redefining and then
re-registering a handler class.

attn @ericdill 