### PR TITLE
BLD: Use .get() instead of directly accessing env

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: filestore
-  version: {{ environ.get('GIT_DESCRIBE_TAG', 'GIT_STUB') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 'inf') }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', 'GIT_STUB')[1:] }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 'inf') }}
 
 source:
   git_url: ../

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: filestore
-  version: {{ environ['GIT_DESCRIBE_TAG'] }}.post{{ environ['GIT_DESCRIBE_NUMBER'] }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', 'GIT_STUB') }}.post{{ environ.get('GIT_DESCRIBE_NUMBER', 'inf') }}
 
 source:
   git_url: ../


### PR DESCRIPTION
conda build master is now using a two-pass jinja system which means
that environ should be accessed via .get() instead of [] if you want
to access GIT_* variables.