### PR TITLE
ENH: Add RawHandler for debugging

### DIFF
--- a/filestore/__init__.py
+++ b/filestore/__init__.py
@@ -8,3 +8,4 @@ from .fs import FileStore, FileStoreRO
 from .core import DatumNotFound
 
 from .handlers_base import HandlerBase
+from .path_only_handlers import RawHandler

--- a/filestore/path_only_handlers.py
+++ b/filestore/path_only_handlers.py
@@ -23,3 +23,16 @@ class AreaDetectorTiffPathOnlyHandler(HandlerBase):
         start, stop = point_number * self._fpp, (point_number + 1) * self._fpp
         return [self._template % (self._path, self._filename, n)
                 for n in range(start, stop)]
+
+
+class RawHandler(HandlerBase):
+    "Return (resoruce_dict, datum_dict) for debugging."
+    def __init__(self, *args, **kwargs):
+        if len(args) > 0:
+            raise ValueError("This handler does not accept positional args.")
+        self.resource_kwargs = kwargs
+
+    def __call__(self, *args, **kwargs):
+        if len(args) > 0:
+            raise ValueError("This handler does not accept positional args.")
+        return self.resource_kwargs, kwargs

--- a/filestore/test/test_handlers.py
+++ b/filestore/test/test_handlers.py
@@ -17,7 +17,8 @@ from filestore.handlers import DummyAreaDetectorHandler
 from filestore.handlers import HDFMapsSpectrumHandler as HDFM
 from filestore.handlers import HDFMapsEnergyHandler as HDFE
 from filestore.handlers import NpyFrameWise
-from filestore.path_only_handlers import AreaDetectorTiffPathOnlyHandler
+from filestore.path_only_handlers import (AreaDetectorTiffPathOnlyHandler,
+                                          RawHandler)
 from numpy.testing import assert_array_equal
 import os
 from itertools import product
@@ -213,3 +214,8 @@ def _test_tiff_path_only(path, fname, fpp):
 def test_tiff_path_handler():
     yield _test_tiff_path_only, '/foo/', 'baz', 1
     yield _test_tiff_path_only, '/foo/', 'baz', 5
+
+def test_raw_handler():
+    h = RawHandler(a=1)
+    result = h(b=2)
+    assert_equal(result, ({'a': 1}, {'b': 2}))


### PR DESCRIPTION
How many times have we wanted to just see the resource/datum documents? Coupled with https://github.com/NSLS-II/databroker/pull/37 you can do:

```python
from filestore import RawHandler
get_images(hdr, 'image', handler_override=RawHandler)
```