### PR TITLE
FIX: major bug in handling of existing FS entries

### DIFF
--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -131,7 +131,7 @@ class FileStoreRO(object):
         else:
             ret = col.find_one({'_id': k})
         if ret is None:
-            raise RuntimeError('did not find resource')
+            raise RuntimeError('did not find resource {!r}'.format(k))
         return ret
 
     def resource_given_uid(self, uid):
@@ -185,18 +185,20 @@ class FileStoreRO(object):
         if self.__db is None:
             conn = self._connection
             self.__db = conn.get_database(self.config['database'])
-            sentinel = self.__db.get_collection('sentinel')
-            versioned_collection = ['resource', 'datum']
-            for col_name in versioned_collection:
-                val = sentinel.find_one({'collection': col_name})
-                if val is None:
-                    raise RuntimeError('there is no version sentinel for '
-                                       'the {} collection'.format(col_name))
-                if val['version'] != self.version:
-                    raise RuntimeError('DB version {!r} does not match'
-                                       'API version of FS {} for the '
-                                       '{} collection'.format(
-                                           val, self.version, col_name))
+            if self.version > 0:
+                sentinel = self.__db.get_collection('sentinel')
+                versioned_collection = ['resource', 'datum']
+                for col_name in versioned_collection:
+                    val = sentinel.find_one({'collection': col_name})
+                    if val is None:
+                        raise RuntimeError('there is no version sentinel for '
+                                           'the {} collection'.format(col_name)
+                                           )
+                    if val['version'] != self.version:
+                        raise RuntimeError('DB version {!r} does not match'
+                                           'API version of FS {} for the '
+                                           '{} collection'.format(
+                                               val, self.version, col_name))
         return self.__db
 
     @property

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -126,13 +126,10 @@ class FileStoreRO(object):
 
     def _r_on_miss(self, k):
         col = self._resource_col
-        if self.version == 0:
-            ret = col.find_one({'_id': k})
-        elif self.version == 1:
+        if isinstance(k, str):
             ret = col.find_one({'uid': k})
         else:
-            raise RuntimeError('{} is not a supported version, must be in'
-                               '{{0, 1}}'.format(self.version))
+            ret = col.find_one({'_id': k})
         return ret
 
     def resource_given_uid(self, uid):
@@ -256,16 +253,18 @@ class FileStoreRO(object):
             document returns the externally stored data
 
         """
+        res_in = resource
         resource = self._resource_cache[resource]
 
         h_cache = self._handler_cache
 
         spec = resource['spec']
         handler = self.handler_reg[spec]
-        if self.version == 0:
-            key = (str(resource['_id']), handler.__name__)
-        elif self.version == 1:
+
+        if isinstance(res_in, str):
             key = (str(resource['uid']), handler.__name__)
+        else:
+            key = (str(resource['_id']), handler.__name__)
 
         try:
             return h_cache[key]

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -126,10 +126,12 @@ class FileStoreRO(object):
 
     def _r_on_miss(self, k):
         col = self._resource_col
-        if isinstance(k, str):
+        if isinstance(k, six.string_types):
             ret = col.find_one({'uid': k})
         else:
             ret = col.find_one({'_id': k})
+        if ret is None:
+            raise RuntimeError('did not find resource')
         return ret
 
     def resource_given_uid(self, uid):
@@ -261,7 +263,7 @@ class FileStoreRO(object):
         spec = resource['spec']
         handler = self.handler_reg[spec]
 
-        if isinstance(res_in, str):
+        if isinstance(res_in, six.string_types):
             key = (str(resource['uid']), handler.__name__)
         else:
             key = (str(resource['_id']), handler.__name__)


### PR DESCRIPTION
Instead of looking at the version the code thinks it is running, look at
the type used to access the resource cache.  The decides how the
resource is searched for (v0 uses _id, v1 used uid).