### PR TITLE
MNT: use unordered bulk inserts

### DIFF
--- a/filestore/core.py
+++ b/filestore/core.py
@@ -80,7 +80,7 @@ def bulk_insert_datum(col, resource, datum_ids,
                          datum_kwargs=dict(d_kwargs))
             yield datum
 
-    bulk = col.initialize_ordered_bulk_op()
+    bulk = col.initialize_unordered_bulk_op()
     for dm in datum_factory():
         bulk.insert(dm)
 


### PR DESCRIPTION
Minor change which could (?) allow parallel inserts with mongo. Indices should take care of the ordering upon insert.