### PR TITLE
ENH: rename 'TIFF' to 'SINGLE_TIFF'

### DIFF
--- a/filestore/handlers.py
+++ b/filestore/handlers.py
@@ -439,7 +439,7 @@ class NpyFrameWise(HandlerBase):
 
 
 class SingleTiffHandler(HandlerBase):
-    specs = {'TIFF'} | HandlerBase.specs
+    specs = {'SINGLE_TIFF'} | HandlerBase.specs
 
     def __init__(self, filename):
         self._name = filename


### PR DESCRIPTION
'TIFF' might not be the best name, so 'SINGLE_TIFF'. See #117 