### PR TITLE
API: raise if trying to copy resource without root

### DIFF
--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -6,3 +6,6 @@ dev
   returns a generator of complete datum documents. The core function was
   exposed through the FileStore method ``datum_gen_given_resource`` which,
   correspondingly, now returns full datum documents, not just datum kwargs.
+
+* trying to copy or move files who's resource does not have a 'root' will
+  intentionally raise.  Previously, this would result in an very obscure error.

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -539,7 +539,6 @@ class FileStore(FileStoreRO):
 
         # get list of files
         resource = dict(self.resource_given_uid(resource_or_uid))
-        resource.setdefault('root', '')
 
         datum_gen = self.datum_gen_given_resource(resource)
         datum_kwarg_gen = (datum['datum_kwargs'] for datum in datum_gen)
@@ -547,6 +546,12 @@ class FileStore(FileStoreRO):
 
         # check that all files share the same root
         old_root = resource['root']
+        if not old_root:
+            raise ValueError("There is no 'root' in this resource which "
+                             "is required to be able to change the root. "
+                             "Please use `fs.shift_root` to move some of "
+                             "the path from the 'resource_path' to the "
+                             "'root'.")
         for f in file_list:
             if not f.startswith(old_root):
                 raise RuntimeError('something is very wrong, the files '


### PR DESCRIPTION
Previously this would raise a very obscure error or maybe work (but
do the wrong thing).

attn @CJ-Wright 