### PR TITLE
added DAT handler

### DIFF
--- a/filestore/handlers.py
+++ b/filestore/handlers.py
@@ -458,19 +458,10 @@ class DATHandler(HandlerBase):
         np.loadtxt
     '''
     specs = {'DAT'} | HandlerBase.specs
-    allowed_kwargs = ['comments', 'delimiter', 'converters', 'skiprows',
-                      'usecols', 'unpack', 'ndmin']
 
     def __init__(self, fpath, **kwargs):
         self._path = fpath
-        # parse kwargs to make sure np.loadtxt can handle them, ignore rest
-        # TODO : maybe warn if there are extra arguments? (symptom of improper
-        # data handling?)
-        newkwargs = dict()
-        for key in self.allowed_kwargs:
-            if key in kwargs:
-                newkwargs[key] = kwargs[key]
-        self.kwargs = newkwargs
+        self.kwargs = kwargs
 
     def __call__(self):
         return np.loadtxt(self._path, **self.kwargs)

--- a/filestore/handlers.py
+++ b/filestore/handlers.py
@@ -446,3 +446,31 @@ class SingleTiffHandler(HandlerBase):
 
     def __call__(self):
         return tifffile.imread(self._name)
+
+
+class DATHandler(HandlerBase):
+    ''' This handles vague text files through numpy's loadtxt module.
+            Useful for the ubiquitous, vague and well loved ".DAT" file.
+            Uses defaults from np.loadtxt.
+
+        See Also
+        --------
+        np.loadtxt
+    '''
+    specs = {'DAT'} | HandlerBase.specs
+    allowed_kwargs = ['comments', 'delimiter', 'converters', 'skiprows',
+                      'usecols', 'unpack', 'ndmin']
+
+    def __init__(self, fpath, **kwargs):
+        self._path = fpath
+        # parse kwargs to make sure np.loadtxt can handle them, ignore rest
+        # TODO : maybe warn if there are extra arguments? (symptom of improper
+        # data handling?)
+        newkwargs = dict()
+        for key in self.allowed_kwargs:
+            if key in kwargs:
+                newkwargs[key] = kwargs[key]
+        self.kwargs = newkwargs
+
+    def __call__(self):
+        return np.loadtxt(self._path, **self.kwargs)


### PR DESCRIPTION
We're using this. Even if this isn't worth pulling, input would be appreciated!
Have not written a test but we tested it on our analysis store.

I assume that this well loved vague file extension can be read to `np.loadtxt` with the proper args. I think it's reasonable?

note: `delimiter=","` loads csv files

@danielballan @licode 