### PR TITLE
Added partial capability

### DIFF
--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -20,8 +20,6 @@ from . import core_v0
 from .handlers_base import DuplicateHandler
 from .utils import _make_sure_path_exists
 
-from functools import partial
-
 _API_MAP = {0: core_v0,
             1: core}
 
@@ -304,12 +302,8 @@ class FileStoreRO(object):
 
         spec = resource['spec']
         handler = self.handler_reg[spec]
-        if isinstance(handler, partial):
-            handler_name = handler.func.__name__
-        else:
-            handler_name = handler.__name__
 
-        key = (str(resource['uid']), handler_name)
+        key = (str(resource['uid']), handler.__name__)
 
         try:
             return h_cache[key]

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -315,13 +315,15 @@ class FileStoreRO(object):
             return h_cache[key]
         except KeyError:
             pass
-
+        
         kwargs = resource['resource_kwargs']
         rpath = resource['resource_path']
         root = resource.get('root', '')
-        root = self.root_map.get(root, root)
         if root:
             rpath = os.path.join(root, rpath)
+        for key, value in self.root_map.items():
+            if rpath.startswith(key):
+                rpath = rpath.replace(key, value)
         ret = handler(rpath, **kwargs)
         h_cache[key] = ret
         return ret

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -20,6 +20,8 @@ from . import core_v0
 from .handlers_base import DuplicateHandler
 from .utils import _make_sure_path_exists
 
+from functools import partial
+
 _API_MAP = {0: core_v0,
             1: core}
 
@@ -302,8 +304,12 @@ class FileStoreRO(object):
 
         spec = resource['spec']
         handler = self.handler_reg[spec]
+        if isinstance(handler, partial):
+            handler_name = handler.func.__name__
+        else:
+            handler_name = handler.__name__
 
-        key = (str(resource['uid']), handler.__name__)
+        key = (str(resource['uid']), handler_name)
 
         try:
             return h_cache[key]

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -309,7 +309,7 @@ class FileStoreRO(object):
             return h_cache[key]
         except KeyError:
             pass
-        
+
         kwargs = resource['resource_kwargs']
         rpath = resource['resource_path']
         root = resource.get('root', '')


### PR DESCRIPTION
(This is just a suggestion, and I'm looking for your insight. :-) )

We've run into a problem of running databroker on different machines where the filepath of the files read by a file handler changes from machine to machine (even though they all read from the same running database).

I think simple solution could be to add some extra kwarg to properly change the filepath, which is basically code like this:
```python
        for key, value in ROOTMAP.items():
            fpath = fpath.replace(key, value)
```

located in here (ignore rest of code, it's a mirror of an existing handler):

``` python
import tifffile
from filestore.handlers_base import HandlerBase
class AreaDetectorTiffHandler(HandlerBase):
    specs = {'AD_TIFF'} | HandlerBase.specs
    def __init__(self, fpath, template, filename, frame_per_point=1,
                ROOTMAP={}):
        # This is hard coded change for CMS Area detector
        for key, value in ROOTMAP.items():
            fpath = fpath.replace(key, value)
        self._path = fpath
        self._fpp = frame_per_point
        self._template = template
        self._filename = filename

    def _fnames_for_point(self, point_number):
        start, stop = point_number * self._fpp, (point_number + 1) * self._fpp
        for j in range(start, stop):
            yield self._template % (self._path, self._filename, j)

    def __call__(self, point_number):
        ret = []
        for fn in self._fnames_for_point(point_number):
            with tifffile.TiffFile(fn) as tif:
                ret.append(tif.asarray())
        return np.array(ret).squeeze()

    def get_file_list(self, datum_kwargs):
        ret = []
        for d_kw in datum_kwargs:
            ret.extend(self._fnames_for_point(**d_kw))
        return ret
```


which then can be initialized by:
```python
from functools import partial
ROOTMAP_DATA= {FROM_DIR : TO_DIR, FROM_DIR_ALT : TO_DIR_ALT, etc} # (directory names omitted)
cmsdb.fs.register_handler('AD_TIFF', partial(AreaDetectorTiffHandler, ROOTMAP=ROOTMAP_DATA))
```

However, for this to work, the FileStore would have to allow for a partially initialized class rather than the class itself (see the diff in the PR here). What do you think? Or is there a better way to do this?
If this isn't possible, we do have the option of hard coding the directory into the code that defines the class. However, this doesn't seem as clean, since the code that instantiates the databroker no longer has control over initializing the file handlers. But this is definitely okay for us.

Also, if you like this, then I'd ask if we can add `ROOTMAP` or similar to the default file handlers themselves.

Thanks!

