### PR TITLE
FIX: fix key error during export

### DIFF
--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -415,7 +415,7 @@ class FileStoreRO(object):
         file_list = self.get_file_list(resource, datum_kwarg_gen)
 
         # check that all files share the same root
-        old_root = resource.get('root', None)
+        old_root = resource.get('root')
         if not old_root:
             warnings.warn("There is no 'root' in this resource which "
                           "is required to be able to change the root. "

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -415,7 +415,7 @@ class FileStoreRO(object):
         file_list = self.get_file_list(resource, datum_kwarg_gen)
 
         # check that all files share the same root
-        old_root = resource['root']
+        old_root = resource.get('root', None)
         if not old_root:
             warnings.warn("There is no 'root' in this resource which "
                           "is required to be able to change the root. "


### PR DESCRIPTION
Fix a key error during export, root can not exist at which point it is `None`.