### PR TITLE
FIX: os.path.join does not like it when the second path has a `/`

### DIFF
--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -315,7 +315,7 @@ class FileStoreRO(object):
         root = resource.get('root', '')
         root = self.root_map.get(root, root)
         if root:
-            rpath = os.path.join(root, rpath)
+            rpath = os.path.join(root, rpath.lstrip('/'))
         ret = handler(rpath, **kwargs)
         h_cache[key] = ret
         return ret

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -315,7 +315,7 @@ class FileStoreRO(object):
         root = resource.get('root', '')
         root = self.root_map.get(root, root)
         if os.path.isabs(rpath):
-            rpath.lstrip('/')
+            rpath = rpath.lstrip('/')
         if not root:
             root = os.sep
         rpath = os.path.join(root, rpath)

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -314,8 +314,11 @@ class FileStoreRO(object):
         rpath = resource['resource_path']
         root = resource.get('root', '')
         root = self.root_map.get(root, root)
-        if root:
-            rpath = os.path.join(root, rpath.lstrip('/'))
+        if os.path.isabs(rpath):
+            rpath.lstrip('/')
+        if not root:
+            root = os.sep
+        rpath = os.path.join(root, rpath.lstrip('/'))
         ret = handler(rpath, **kwargs)
         h_cache[key] = ret
         return ret

--- a/filestore/fs.py
+++ b/filestore/fs.py
@@ -318,7 +318,7 @@ class FileStoreRO(object):
             rpath.lstrip('/')
         if not root:
             root = os.sep
-        rpath = os.path.join(root, rpath.lstrip('/'))
+        rpath = os.path.join(root, rpath)
         ret = handler(rpath, **kwargs)
         h_cache[key] = ret
         return ret

--- a/filestore/test/test_fs.py
+++ b/filestore/test/test_fs.py
@@ -24,7 +24,6 @@ def test_insert_funcs(func, fs):
 
 
 def test_non_exist(fs):
-
     with pytest.raises(fs.DatumNotFound):
         fs.retrieve('aardvark')
 
@@ -37,9 +36,10 @@ def test_non_unique_fail(fs):
     with pytest.raises(fs.DuplicateKeyError):
         fs.insert_datum(str(fb['id']), r_id, {'n': 1})
 
+
 def test_root(fs):
     print(fs._db)
-    res = fs.insert_resource('root-test', 'foo', {}, root='bar')
+    res = fs.insert_resource('root-test', 'foo', {}, root='/bar')
     dm = fs.insert_datum(res, str(uuid.uuid4()), {})
     if fs.version == 1:
         assert res['root'] == 'bar'


### PR DESCRIPTION
in the starting position, we `lstrip('/')` just in case.